### PR TITLE
increase parallelism and timeout

### DIFF
--- a/collyfunc/collyfunc.go
+++ b/collyfunc/collyfunc.go
@@ -48,7 +48,7 @@ func GetColly(proxy string, scrapStatus string, requestCount int, responseBytes 
 	// pass transport to collector
 	c.WithTransport(transport)
 
-	c.SetRequestTimeout(60 * time.Second)
+	c.SetRequestTimeout(100 * time.Second)
 
 	c.OnRequest(func(r *colly.Request) {
 		requestCount += 1
@@ -74,9 +74,9 @@ func GetColly(proxy string, scrapStatus string, requestCount int, responseBytes 
 
 	c.Limit(&colly.LimitRule{
 		DomainGlob:  "*",
-		Parallelism: 7,
+		Parallelism: 10,
 		Delay:       3 * time.Second,
-		RandomDelay: 2 * time.Second,
+		RandomDelay: 3 * time.Second,
 	})
 
 	return c


### PR DESCRIPTION
Asana Task:[1200145374025856](https://app.asana.com/0/630636295096259/1200145374025856)
1. increase parallelism to reduce time duration
2. increase request timeout out to reduce client timeout error